### PR TITLE
Fixes deps typo

### DIFF
--- a/server/deps.edn
+++ b/server/deps.edn
@@ -2,7 +2,7 @@
         org.clojure/clojure {:mvn/version "1.10.1"}
         cljs-http {:mvn/version "0.1.46"}
 
-        thheller/shadow.cljs {:mvn/version "2.8.110"}}
+        thheller/shadow-cljs {:mvn/version "2.8.110"}}
 
  :paths ["src"]
 


### PR DESCRIPTION
This might be why it wasn't starting since the dependency doesn't exist.